### PR TITLE
Add maven section for appcompat

### DIFF
--- a/VAHelper/build.gradle
+++ b/VAHelper/build.gradle
@@ -16,6 +16,9 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        maven {
+            url "https://maven.google.com"
+        }
     }
 }
 


### PR DESCRIPTION
* What went wrong:
Could not resolve all files for configuration ':VAHelperLib:debugCompileClasspath'.
> Could not find com.android.support:appcompat-v7:25.1.0.